### PR TITLE
Always redirect setting

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,11 @@
   "background": {
     "page": "src/bg/background.html"
   },
+  "options_ui": {
+    "page": "src/settings/settings.html",
+    "browser_style": true,
+    "chrome_style": true
+  },
   "page_action": {
     "default_icon": "icons/icon48.png"
   },

--- a/src/functions.js
+++ b/src/functions.js
@@ -117,7 +117,7 @@ function handleCustomTarget(target, tabId, hostname) {
  * @param event {object}
  */
 function navigationCompleteListener(event) {
-    getStorage(URLS_KEY, storage => {
+    getStorage([URLS_KEY, ALWAYS_REDIRECT_KEY], storage => {
         const tabId = event.tabId;
         const url = event.url;
         const hostname = extractHostname(url);
@@ -151,12 +151,18 @@ function navigationCompleteListener(event) {
             return;
         }
 
-        enableLinking(
-            target["link"],
-            tabId,
-            hostname,
-            target['name_short'] + " heeft ook een gesponsorde link!"
-        );
+        if (storage[ALWAYS_REDIRECT_KEY]) {
+            // Immediately redirect to the affiliated link
+            sponsortabs[tabId] = hostname;
+            navigateTo(tabId, target['link']);
+        } else {
+            enableLinking(
+                target["link"],
+                tabId,
+                hostname,
+                target['name_short'] + " heeft ook een gesponsorde link!"
+            );
+        }
     });
 }
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -2,6 +2,7 @@ const CLUBID = 4509;
 const API = "https://www.sponsorkliks.com/api/?club="+CLUBID+"&call=webshops_club_extension";
 const URLS_KEY = "urls";
 const LASTCHECK_KEY = "lastcheck";
+const ALWAYS_REDIRECT_KEY = "always-redirect";
 const NOTIFICATION_ID = "sponsor-notification-";
 const UPDATE_CHECK_INTERVAL = 600;
 const CUSTOM_TARGETS = {};

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta charset="utf-8"/>
+        <title>C.S.V. Alpha Sponsor Extensie - Instellingen</title>
+    </head>
+
+    <body>
+        <form id="settings">
+            <p>
+                <label for="always-redirect">
+                    <input type="checkbox" name="always-redirect" id="always-redirect"/>
+                    &nbsp;&nbsp;Altijd doorsturen
+                </label>
+            </p>
+            <button type="submit">Save</button>
+        </form>
+        <script src="/src/functions.js"></script>
+        <script src="settings.js"></script>
+    </body>
+</html>

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -4,6 +4,15 @@
     <head>
         <meta charset="utf-8"/>
         <title>C.S.V. Alpha Sponsor Extensie - Instellingen</title>
+        <style>
+            #settings-saved {
+                color: green;
+            }
+            form {
+                margin-top: 5px;
+                margin-bottom: 25px;
+            }
+        </style>
     </head>
 
     <body>
@@ -11,10 +20,10 @@
             <p>
                 <label for="always-redirect">
                     <input type="checkbox" name="always-redirect" id="always-redirect"/>
-                    &nbsp;&nbsp;Altijd doorsturen
+                    &nbsp;&nbsp;Automatisch doorsturen naar affiliate link
                 </label>
             </p>
-            <button type="submit">Save</button>
+            <p id="settings-saved"></p>
         </form>
         <script src="/src/functions.js"></script>
         <script src="settings.js"></script>

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -1,0 +1,25 @@
+/**
+ * Called when the DOM is loaded
+ * Restores the saved settings
+ */
+function restoreOptions() {
+    getStorage(ALWAYS_REDIRECT_KEY, storage => {
+        if (storage[ALWAYS_REDIRECT_KEY]) {
+            document.getElementById('always-redirect').checked = true;
+        }
+    });
+}
+document.addEventListener('DOMContentLoaded', restoreOptions);
+
+/**
+ * Called when the form is submitted
+ * @param e {object} submit event
+ */
+function saveOptions(e) {
+    e.preventDefault();
+
+    browser.storage.local.set({
+        [ALWAYS_REDIRECT_KEY]: document.querySelector('#always-redirect').checked
+    });
+}
+document.getElementById('settings').addEventListener('submit', saveOptions);

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -19,7 +19,14 @@ function saveOptions(e) {
     e.preventDefault();
 
     browser.storage.local.set({
-        [ALWAYS_REDIRECT_KEY]: document.querySelector('#always-redirect').checked
+        [ALWAYS_REDIRECT_KEY]: document.getElementById('always-redirect').checked
     });
+
+    const settingsSaved = document.getElementById('settings-saved');
+    console.log("Settings saved");
+    settingsSaved.innerHTML = "Wijzigingen opgeslagen";
+    setTimeout(function() {
+        settingsSaved.innerText = "";
+    }, 1000)
 }
-document.getElementById('settings').addEventListener('submit', saveOptions);
+document.getElementById('always-redirect').addEventListener('change', saveOptions);


### PR DESCRIPTION
Add an always redirect setting that, when enabled, will always redirect to an affiliate link without showing a notification or page action.