### PR TITLE
Redirect back to user original page

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -11,16 +11,6 @@ const CUSTOM_TARGETS = {
         'name_short': 'Albert Heijn',
         'link': 'https://www.sponsorkliks.com/link.php?club=4509&shop_id=2670&shop=Albert+Heijn&link=aHR0cCUzQSUyRiUyRnByZi5obiUyRmNsaWNrJTJGY2FtcmVmJTNBMTEwMGx3eWQlMkZwdWJyZWYlM0FTS180'
     },
-    'bol.com': {
-        'category': 'Speelgoed',
-        'name_short': 'bol.com',
-        'link': 'https://www.sponsorkliks.com/link.php?club=4509&shop_id=12&shop=bol.com&link=aHR0cCUzQSUyRiUyRnBhcnRuZXJwcm9ncmFtbWEuYm9sLmNvbSUyRmNsaWNrJTJGY2xpY2slM0ZwJTNEMSUyNnQlM0R1cmwlMjZzJTNEODk2OCUyNnVybCUzRGh0dHAlMjUzQSUyRiUyRnd3dy5ib2wuY29tJTI2ZiUzRFRYTCUyNnN1YmlkJTNEU0tfNCUyNm5hbWUlM0Rib2wlMjUyMGhvbWU='
-    },
-    'conrad.nl': {
-        'category': 'Computers & Electronica',
-        'name_short': 'Conrad',
-        'link': 'https://www.sponsorkliks.com/link.php?club=4509&shop_id=1797&shop=Conrad&link=aHR0cCUzQSUyRiUyRnd3dy5jb25yYWQtZWxlY3Ryb25pYy5ubCUyRnR0JTJGJTNGdHQlM0Q5MjBfMTJfOTU0NzFfU0s0JTI2ciUzRA=='
-    },
     'coolblue.nl': {
         'category': 'Computers & Electronica',
         'name_short': 'Coolblue',
@@ -45,12 +35,7 @@ const CUSTOM_TARGETS = {
         'category': 'Eten & Drinken',
         'name_short': 'Thuisbezorgd.nl',
         'link': 'https://www.sponsorkliks.com/link.php?club=4509&shop_id=4&shop=Thuisbezorgd.nl&link=aHR0cCUzQSUyRiUyRnd3dy5hd2luMS5jb20lMkZhd2NsaWNrLnBocCUzRmdpZCUzRDM0MjkwMSUyNm1pZCUzRDEwNTEwJTI2YXdpbmFmZmlkJTNEMzI4ODQxJTI2bGlua2lkJTNEMjIxMTM1MSUyNmNsaWNrcmVmJTNEU0tfNA=='
-    },
-    'woonexpress.nl': {
-        'category': 'Huis & Tuin',
-        'name_short': 'Woonexpress',
-        'link': 'https://www.sponsorkliks.com/link.php?club=4509&shop_id=3114&shop=Woonexpress+NL&link=aHR0cCUzQSUyRiUyRnd3dy5hd2luMS5jb20lMkZhd2NsaWNrLnBocCUzRmdpZCUzRDMyMDEyOSUyNm1pZCUzRDg0OTQlMjZhd2luYWZmaWQlM0QzMjg4NDElMjZsaW5raWQlM0QyMDIyMzUxJTI2Y2xpY2tyZWYlM0RTS180'
-    },
+    }
 };
 const CHROME = typeof browser === 'undefined';
 
@@ -85,6 +70,13 @@ async function updateURLs() {
     const response = await fetch(API);
     const data = await response.json();
 
+    // Add custom targets that are not present in the API
+    for (var url in CUSTOM_TARGETS) {
+        var custom_data = CUSTOM_TARGETS[url];
+        custom_data['orig_url'] = url;
+        data['webshops'].push(custom_data)
+    }
+
     browser.storage.local.set({
         [URLS_KEY]: data['webshops']
             .filter(obj => !!obj.orig_url)
@@ -109,13 +101,14 @@ function navigateTo(tabId, target) {
  * @param link {string} affiliate link
  * @param tabId {number} tab id of the website
  * @param hostname {string} hostname of the website
+ * @param referer {string} url of the website to redirect to after redirect from sponsorkliks.nl
  * @param notificationTitle {string} title of the notification
  */
-function enableLinking(link, tabId, hostname, notificationTitle) {
+function enableLinking(link, tabId, hostname, referer, notificationTitle) {
     // Page action
     browser.pageAction.show(tabId);
     browser.pageAction.onClicked.addListener(function () {
-        sponsortabs[tabId] = hostname;
+        sponsortabs[tabId] = {'hostname': hostname, 'referer': referer};
         browser.notifications.clear(NOTIFICATION_ID);
         navigateTo(tabId, link);
     });
@@ -131,38 +124,11 @@ function enableLinking(link, tabId, hostname, notificationTitle) {
 
     browser.notifications.onClicked.addListener(function (notificationId) {
         if (notificationId === NOTIFICATION_ID+tabId) {
-            sponsortabs[tabId] = hostname;
+            sponsortabs[tabId] = {'hostname': hostname, 'referer': referer};
             browser.notifications.clear(notificationId);
             navigateTo(tabId, link);
         }
     });
-}
-
-/**
- * Handle a website that has a custom affiliate link that was not received via the API
- * @param target {array} target information
- * @param tabId {number} tab id of the website
- * @param hostname {string} hostname of the website
- * @param storage {object} storage object with at least the value of ALWAYS_REDIRECT_KEY
- */
-function handleCustomTarget(target, tabId, hostname, storage) {
-    // Check if we're still visiting the same site we already went through a sponsored link for
-    if (hostname === sponsortabs[tabId]) {
-        return;
-    }
-
-    if (storage[ALWAYS_REDIRECT_KEY]) {
-        // Immediately redirect to the affiliated link
-        sponsortabs[tabId] = hostname;
-        navigateTo(tabId, target['link']);
-    } else {
-        enableLinking(
-            target['link'],
-            tabId,
-            hostname,
-            target['name_short'] + ' heeft een C.S.V. Alpha affiliate link!'
-        );
-    }
 }
 
 /**
@@ -182,11 +148,6 @@ function navigationCompleteListener(event) {
             return;
         }
 
-        // If we have a custom affiliate link for the current target
-        if (custom_target) {
-            return handleCustomTarget(custom_target, tabId, hostname, storage);
-        }
-
         const urls = storage[URLS_KEY];
         if (!urls) {
             // Apparently we were not able to retrieve the urls from the API yet
@@ -200,19 +161,25 @@ function navigationCompleteListener(event) {
         }
 
         // Check if we're still visiting the same site we already went through a sponsored link for
-        if (hostname === sponsortabs[tabId]) {
+        if (sponsortabs[tabId] && hostname === sponsortabs[tabId]['hostname']) {
+            // If we have a origin location we came for, redirect back to that page
+            if(sponsortabs[tabId]['referer']){
+                navigateTo(tabId, sponsortabs[tabId]['referer']);
+                sponsortabs[tabId]['referer'] = null;
+            }
             return;
         }
 
         if (storage[ALWAYS_REDIRECT_KEY]) {
             // Immediately redirect to the affiliated link
-            sponsortabs[tabId] = hostname;
+            sponsortabs[tabId] = {'hostname': hostname, 'referer': url};
             navigateTo(tabId, target['link']);
         } else {
             enableLinking(
                 target['link'],
                 tabId,
                 hostname,
+                url,
                 target['name_short'] + ' heeft ook een gesponsorde link!'
             );
         }

--- a/src/functions.js
+++ b/src/functions.js
@@ -101,14 +101,14 @@ function navigateTo(tabId, target) {
  * @param link {string} affiliate link
  * @param tabId {number} tab id of the website
  * @param hostname {string} hostname of the website
- * @param referer {string} url of the website to redirect to after redirect from sponsorkliks.nl
+ * @param referrer {string} url of the website to redirect to after redirect from sponsorkliks.nl
  * @param notificationTitle {string} title of the notification
  */
-function enableLinking(link, tabId, hostname, referer, notificationTitle) {
+function enableLinking(link, tabId, hostname, referrer, notificationTitle) {
     // Page action
     browser.pageAction.show(tabId);
     browser.pageAction.onClicked.addListener(function () {
-        sponsortabs[tabId] = {'hostname': hostname, 'referer': referer};
+        sponsortabs[tabId] = {'hostname': hostname, 'referrer': referrer};
         browser.notifications.clear(NOTIFICATION_ID);
         navigateTo(tabId, link);
     });
@@ -124,7 +124,7 @@ function enableLinking(link, tabId, hostname, referer, notificationTitle) {
 
     browser.notifications.onClicked.addListener(function (notificationId) {
         if (notificationId === NOTIFICATION_ID+tabId) {
-            sponsortabs[tabId] = {'hostname': hostname, 'referer': referer};
+            sponsortabs[tabId] = {'hostname': hostname, 'referrer': referrer};
             browser.notifications.clear(notificationId);
             navigateTo(tabId, link);
         }
@@ -163,16 +163,16 @@ function navigationCompleteListener(event) {
         // Check if we're still visiting the same site we already went through a sponsored link for
         if (sponsortabs[tabId] && hostname === sponsortabs[tabId]['hostname']) {
             // If we have a origin location we came for, redirect back to that page
-            if(sponsortabs[tabId]['referer']){
-                navigateTo(tabId, sponsortabs[tabId]['referer']);
-                sponsortabs[tabId]['referer'] = null;
+            if(sponsortabs[tabId]['referrer']){
+                navigateTo(tabId, sponsortabs[tabId]['referrer']);
+                sponsortabs[tabId]['referrer'] = null;
             }
             return;
         }
 
         if (storage[ALWAYS_REDIRECT_KEY]) {
             // Immediately redirect to the affiliated link
-            sponsortabs[tabId] = {'hostname': hostname, 'referer': url};
+            sponsortabs[tabId] = {'hostname': hostname, 'referrer': url};
             navigateTo(tabId, target['link']);
         } else {
             enableLinking(


### PR DESCRIPTION
This PR does 3 things. 

First, it removes the custom target logic on page load. The custom targets are now added to the API response, such that they get saved into the database. This prevents us from handling them separate from the other type of source (since they are actually the same).

Second, we save the referer, the page were the user came from, such that we can redirect the user back. This works as follows. 
1) A user goes to bol.com/some-page
2) The user gets asked to activate sponsorkliks 
3) The user gets redirected to sponsorkliks and back to bol.com/?some_sponsorkliks_info 
4) The user gets redirected to bol.com/some-page

Step 1,2,3 were already implemented, step 4 is the new one.

Last, a few custom targets are removed since they are now present in the API. 