### PR TITLE
Add attribute to document to detect extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,15 @@
   "background": {
     "page": "src/bg/background.html"
   },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*.csvalpha.nl/*"
+      ],
+      "js": ["src/installed.js"],
+      "run_at": "document_end"
+    }
+  ],
   "options_ui": {
     "page": "src/settings/settings.html",
     "browser_style": true,

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
         "*://*.csvalpha.nl/*"
       ],
       "js": ["src/installed.js"],
-      "run_at": "document_end"
+      "run_at": "document_start"
     }
   ],
   "options_ui": {

--- a/src/installed.js
+++ b/src/installed.js
@@ -1,0 +1,1 @@
+document.documentElement.setAttribute('data-sponsorkliks-extension', '1');


### PR DESCRIPTION
With this PR, a `data-sponsorkliks-extension="1"` attribute is added to the document (`<head>`) tag of csvalpha.nl. This is consistent with what the Ember extension does. With this change, we will be able to check on csvalpha.nl if the extension is installed, and if not, for example, show a notification that suggests installing the extension.