### PR TITLE
Remove activeTab permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,6 @@
     "webNavigation",
     "alarms",
     "notifications",
-    "activeTab",
     "storage",
     "*://*.sponsorkliks.nl/api/*"
   ],


### PR DESCRIPTION
The activeTab permission doesn't seem to be needed for anything.